### PR TITLE
:sparkles: Monitor Axone Agentic Airdrop Web Site

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -5,6 +5,8 @@ sites:
     url: "https://axone.xyz"
   - name: Axone Documentation Site
     url: "https://docs.axone.xyz"
+  - name: Axone Agentic Airdrop Web Site
+    url: "https://airdrop.axone.xyz"
   - name: Axone Faucet
     url: "https://faucet.okp4.network"
   - name: Axone Explorer


### PR DESCRIPTION
Just keep an eye on: https://airdrop.axone.xyz/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded site monitoring with the addition of the "Axone Agentic Airdrop Web Site" available at [https://airdrop.axone.xyz](https://airdrop.axone.xyz).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->